### PR TITLE
(feat) endpoint for retrieving similar context stores

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -8,6 +8,7 @@ from fastapi import BackgroundTasks, File, HTTPException, UploadFile
 from app.api.requests import (
     BusinessGlossaryRequest,
     ContextStoreRequest,
+    SemanticContextStoreRequest,
     DatabaseConnectionRequest,
     InstructionRequest,
     NLGenerationRequest,
@@ -197,6 +198,14 @@ class API:
             "/api/v1/context-stores/{context_store_id}",
             self.get_context_store,
             methods=["GET"],
+            tags=["Context Stores"],
+        )
+
+        self.router.add_api_route(
+            "/api/v1/context-stores/semantic-search",
+            self.get_semantic_context_stores,
+            methods=["POST"],
+            status_code=201,
             tags=["Context Stores"],
         )
 
@@ -584,6 +593,17 @@ class API:
     def get_context_store(self, context_store_id: str) -> ContextStoreResponse:
         context_store = self.context_store_service.get_context_store(context_store_id)
         return ContextStoreResponse(**context_store.model_dump())
+    
+    def get_semantic_context_stores(
+        self, context_store_request: SemanticContextStoreRequest
+    ) -> list[dict]:
+        semantic_context_stores = self.context_store_service.get_semantic_context_stores(
+            context_store_request.db_connection_id, context_store_request.prompt_text, context_store_request.top_k
+        )
+        
+        return [
+            context_store for context_store in semantic_context_stores
+        ]
 
     def delete_context_store(self, context_store_id: str) -> dict:
         try:

--- a/app/api/requests.py
+++ b/app/api/requests.py
@@ -76,6 +76,11 @@ class ContextStoreRequest(BaseModel):
     sql: str
     metadata: dict | None = None
 
+class SemanticContextStoreRequest(BaseModel):
+    db_connection_id: str
+    prompt_text: str
+    top_k: int = 3
+
 
 class UpdateContextStoreRequest(BaseModel):
     prompt_text: Optional[str] = None

--- a/app/data/db/storage.py
+++ b/app/data/db/storage.py
@@ -147,6 +147,17 @@ class Storage(TypeSenseDB):
         if results:
             if results["results"][0]["found"] > 0:
                 hits = results["results"][0]["hits"]
+
+                # Deduplicate by prompt_text
+                unique_hits = {}
+                for hit in hits:
+                    prompt_text = hit["document"]["prompt_text"].lower()
+                    if prompt_text not in unique_hits:
+                        unique_hits[prompt_text] = hit  # Keep the first occurrence
+
+                # Convert dictionary values back to a list
+                hits = list(unique_hits.values())
+
                 # Sort results by vector_distance asc
                 sorted_hits = sorted(
                     hits,

--- a/app/data/db/storage.py
+++ b/app/data/db/storage.py
@@ -147,19 +147,20 @@ class Storage(TypeSenseDB):
         if results:
             if results["results"][0]["found"] > 0:
                 hits = results["results"][0]["hits"]
-                # Sort results by rank_fusion_score desc
+                # Sort results by vector_distance asc
                 sorted_hits = sorted(
                     hits,
-                    key=lambda x: x["hybrid_search_info"]["rank_fusion_score"],
-                    reverse=True,
+                    key=lambda x: x["vector_distance"],
+                    reverse=False,
                 )
                 # Take top N results
                 sorted_hits = sorted_hits[:limit]
 
+                # Remapping vector_distance between 0 and 1. Higher is more similar
                 return [
                     {
                         **hit["document"],
-                        "score": hit["hybrid_search_info"]["rank_fusion_score"],
+                        "score": 1 - (hit['vector_distance']/2)
                     }
                     for hit in sorted_hits
                 ]

--- a/app/modules/context_store/services/__init__.py
+++ b/app/modules/context_store/services/__init__.py
@@ -119,6 +119,22 @@ class ContextStoreService:
     def get_context_stores(self, db_connection_id) -> list[ContextStore]:
         filter = {"db_connection_id": db_connection_id}
         return self.repository.find_by(filter)
+    
+    def get_semantic_context_stores(
+            self, db_connection_id: str, prompt: str, top_k: int
+    ) -> list[ContextStore]:
+        embedding_model = EmbeddingModel().get_model()
+        prompt_embedding = embedding_model.embed_query(prompt)
+
+        semantic_contexts = self.repository.find_by_relevance(
+            db_connection_id=db_connection_id,
+            prompt_text=prompt,
+            prompt_embedding=prompt_embedding,
+            limit=top_k,
+            alpha=1.0
+        )
+        
+        return semantic_contexts
 
     def update_context_store(
         self, context_store_id, update_request: UpdateContextStoreRequest

--- a/app/modules/context_store/services/__init__.py
+++ b/app/modules/context_store/services/__init__.py
@@ -130,9 +130,17 @@ class ContextStoreService:
             db_connection_id=db_connection_id,
             prompt_text=prompt,
             prompt_embedding=prompt_embedding,
-            limit=top_k,
+            limit=top_k+1,
             alpha=1.0
         )
+
+        # Exclude the exact match
+        semantic_contexts = [
+            context
+            for context in semantic_contexts
+            if context['prompt_text'].lower() != prompt.lower()
+            and context['score'] < 0.99
+        ][:top_k]
         
         return semantic_contexts
 

--- a/docs/apis/context-store-api.md
+++ b/docs/apis/context-store-api.md
@@ -78,7 +78,7 @@
 
 **Endpoint:** `/api/v1/context-stores/semantic-search`\
 **Method:** `POST`\
-**Description:** Retrieves the details of `top k` most similar context store entries.
+**Description:** Retrieves the details of `top k` most similar context store entries excluding the exact match.
 
 **Response:**
 

--- a/docs/apis/context-store-api.md
+++ b/docs/apis/context-store-api.md
@@ -74,7 +74,23 @@
 }
 ```
 
-#### 4. Update a Context Store
+#### 4. Retrieve Similar Context Stores
+
+**Endpoint:** `/api/v1/context-stores/semantic-search`\
+**Method:** `POST`\
+**Description:** Retrieves the details of `top k` most similar context store entries.
+
+**Response:**
+
+```json
+{
+    "db_connection_id": "string",
+    "prompt": "string",
+    "top_k": "int"
+}
+```
+
+#### 5. Update a Context Store
 
 **Endpoint:** `/api/v1/context-stores/{context_store_id}`\
 **Method:** `PUT`\
@@ -103,7 +119,7 @@
 }
 ```
 
-#### 5. Delete a Context Store
+#### 6. Delete a Context Store
 
 **Endpoint:** `/api/v1/context-stores/{context_store_id}`\
 **Method:** `DELETE`\
@@ -201,6 +217,35 @@ GET /api/v1/context-stores/ctx123
     "metadata": {"created_by": "admin"},
     "created_at": "2024-09-09T12:34:56Z"
 }
+```
+
+#### Retrieving Similar Context Stores
+
+To retrieve a specific context store, send a `POST` request to `/api/v1/context-stores/semantic-search`:
+
+**Request:**
+
+```http
+POST /api/v1/context-stores/semantic-search
+Content-Type: application/json
+
+{
+    "db_connection_id": "db123"
+    "prompt": How many regency in,
+    "top_k": 3
+}
+```
+
+**Response:**
+
+```json
+[
+    {
+        "prompt_text": "How many regency in Kutai?",
+        "sql": "SELECT SUM(amount) AS revenue FROM sales",
+        "score": "0.8117260634899139"
+    }
+]
 ```
 
 #### Updating a Context Store


### PR DESCRIPTION
- Modified the similarity score calculation by replacing the `rank_fusion_score` with `vector_distance`. The new score is normalized to a range between 0 and 1, where a higher score indicates greater similarity.
- Added a new endpoint to retrieve the top-k most similar context stores using vector similarity.
- Exclude exact entries on semantic search.
- Add logic to deduplicate entries by `promp_text` on hybrid search.