### PR TITLE
Disable duplicate alias name check for alias creation

### DIFF
--- a/app/modules/alias/services/__init__.py
+++ b/app/modules/alias/services/__init__.py
@@ -19,12 +19,12 @@ class AliasService:
 
     def create_alias(self, alias_request: AliasRequest) -> Alias:
         # Check if alias with the same name already exists
-        existing_alias = self.repository.find_by_name(alias_request.name)
-        if existing_alias:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Alias with name '{alias_request.name}' already exists",
-            )
+        # existing_alias = self.repository.find_by_name(alias_request.name)
+        # if existing_alias:
+        #     raise HTTPException(
+        #         status_code=400,
+        #         detail=f"Alias with name '{alias_request.name}' already exists",
+        #     )
 
         alias = Alias(
             db_connection_id=alias_request.db_connection_id,
@@ -45,17 +45,17 @@ class AliasService:
     def get_alias_by_name(self, name: str, db_connection_id: str) -> Alias:
         """
         Get an alias by name using full-text search within the specified db_connection_id.
-        
+
         This method uses full-text search to find aliases with names that match or are similar
         to the provided name, filtered by the specified db_connection_id.
-        
+
         Args:
             name: The name or partial name of the alias to search for
             db_connection_id: The database connection ID to filter by
-            
+
         Returns:
             The matched alias
-            
+
         Raises:
             HTTPException: If no alias is found with the given name in the specified db_connection
         """
@@ -66,7 +66,9 @@ class AliasService:
             )
         return alias
 
-    def get_aliases(self, db_connection_id: str, target_type: str = None) -> list[Alias]:
+    def get_aliases(
+        self, db_connection_id: str, target_type: str = None
+    ) -> list[Alias]:
         filter = {"db_connection_id": db_connection_id}
         if target_type:
             filter["target_type"] = target_type


### PR DESCRIPTION
The validation logic that prevented creating aliases with existing names has been commented out in `AliasService.create_alias`. This allows for the creation of aliases with non-unique names