### PR TITLE
feat(sql-generation): add endpoint to stream sql results to gcs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ GOOGLE_API_KEY=
 OLLAMA_API_BASE= "http://localhost:11434"
 HUGGINGFACEHUB_API_TOKEN=
 
+GLINER_API_BASE=
+
+GCS_API_KEY=
+GCS_SERVICE_URL= 
+
 # use different tools you can set the "AGENT_MAX_ITERATIONS" env variable. By default it is set to 20 iterations.
 AGENT_MAX_ITERATIONS=20
 #timeout in seconds for the engine to return a response. Defaults to 150 seconds

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -349,6 +349,13 @@ class API:
         )
 
         self.router.add_api_route(
+            "/api/v1/sql-generations/{sql_generation_id}/execute-to-gcs",
+            self.execute_sql_query_to_gcs,
+            methods=["POST"],
+            tags=["SQL Generations"],
+        )
+
+        self.router.add_api_route(
             "/api/v1/sql-generations/{sql_generation_id}/nl-generations",
             self.create_nl_generation,
             methods=["POST"],
@@ -800,6 +807,13 @@ class API:
             sql_generation_id, max_rows
         )
 
+    def execute_sql_query_to_gcs(
+        self, sql_generation_id: str, max_rows: int = 100
+    ) -> dict:
+        return self.sql_generation_service.stream_sql_result_to_gcs(
+            sql_generation_id, max_rows
+        )
+
     def create_nl_generation(
         self, sql_generation_id: str, nl_generation_request: NLGenerationRequest
     ) -> NLGenerationResponse:
@@ -942,7 +956,9 @@ class API:
             created_at=alias.created_at,
         )
 
-    def get_aliases(self, db_connection_id: str, target_type: str = None) -> list[AliasResponse]:
+    def get_aliases(
+        self, db_connection_id: str, target_type: str = None
+    ) -> list[AliasResponse]:
         aliases = self.alias_service.get_aliases(db_connection_id, target_type)
         return [
             AliasResponse(

--- a/app/server/config.py
+++ b/app/server/config.py
@@ -38,6 +38,9 @@ class Settings(BaseSettings):
     OLLAMA_API_BASE: str | None
     HUGGINGFACEHUB_API_TOKEN: str | None
 
+    GCS_API_KEY: str | None
+    GCS_SERVICE_URL: str | None
+
     AGENT_MAX_ITERATIONS: int
     DH_ENGINE_TIMEOUT: int
     SQL_EXECUTION_TIMEOUT: int

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     container_name: text2sql-agent
     restart: on-failure
     ports:
-      - "8005:8005"
+      - "8015:8005"
     depends_on:
       - typesense
     env_file:


### PR DESCRIPTION
Introduces a new API endpoint to execute a SQL query and stream its
results to a Google Cloud Storage bucket as a CSV file. This enables
exporting large datasets securely using signed URLs.

New environment variables `GCS_API_KEY` and `GCS_SERVICE_URL` are
required for GCS integration. The `docker-compose` port for the
`text2sql-agent` has been updated from 8005 to 8015.